### PR TITLE
ci(workflow/release): add linux binaries to release workflow

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Changes
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,11 @@ on:
     types: [created]
 
 jobs:
-  release:
+  publish-crate:
+    name: Publish crate
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
         name: Checkout repository
@@ -22,3 +25,36 @@ jobs:
         name: Publish crate
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  build-linux-binaries:
+    name: Build x86_64 Linux binaries
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout repository
+      - uses: actions-rs/toolchain@v1
+        name: Set up toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+        name: Cache toolchain and dependencies
+      - name: Build x86_64 Linux binaries
+        run: |
+          cargo build --release
+          mkdir ./quincy-linux-x86_64
+          cp target/release/quincy-client quincy-linux-x86_64/
+          cp target/release/quincy-server quincy-linux-x86_64/
+          cp target/release/quincy-users quincy-linux-x86_64/
+          tar zcf quincy-linux-x86_64.tar.gz -C quincy-linux-x86_64 .
+      - uses: softprops/action-gh-release@v1
+        name: Add binary to release
+        with:
+          files: |
+            quincy-linux-x86_64.tar.gz

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   test:
+    name: Test crate
+
     strategy:
       matrix:
 #        unnecessary until macos-latest runs on arm64 arch
@@ -37,6 +39,8 @@ jobs:
           command: test
 
   lint:
+    name: Check code style
+
     strategy:
       matrix:
 #        unnecessary until macos-latest runs on arm64 arch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "QUIC-based VPN"
 readme = "README.md"
 homepage = "https://github.com/M0dEx/quincy"
 repository = "https://github.com/M0dEx/quincy"
-keywords = ["vpn", "quic", "tunnel", "networking", "tokio", "async"]
+keywords = ["vpn", "quic", "tunnel", "networking", "tokio"]
 categories = ["command-line-utilities", "network-programming"]
 edition = "2021"
 


### PR DESCRIPTION
This PR adds the building of Linux libraries to the release workflow.

It also adds names to different jobs, automatically generated changelog and fixes an issue in `Cargo.toml`.