### PR TITLE
fix(client): fetch maximum datagram size after TUN read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "quincy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quincy"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "MIT"
 description = "QUIC-based VPN"

--- a/src/client.rs
+++ b/src/client.rs
@@ -163,11 +163,11 @@ impl QuincyClient {
         debug!("Started outgoing traffic task (interface -> QUIC tunnel)");
 
         loop {
+            let data = read_from_interface(&mut read_interface, interface_mtu).await?;
+
             let quinn_mtu = connection
                 .max_datagram_size()
                 .ok_or_else(|| anyhow!("The Quincy server does not support datagram transfer"))?;
-
-            let data = read_from_interface(&mut read_interface, interface_mtu).await?;
 
             if data.len() > quinn_mtu {
                 warn!(


### PR DESCRIPTION
This PR fixes a race condition where fetching the maximum datagram size limit occurred too soon (before reading from the TUN interface) causing the limit to be too old (and in some high-throughput cases, incorrect, due to congestion) when `connection.send_datagram` was called, which resulted in the datagram being rejected by the QUIC connection leading to an unrecoverable error.

By moving the fetch right before the size check and the `connection.send_datagram`, this error is now recoverable, as MTU path discovery updates the maximum MTU to a reasonable value after some time passes (from my testing about 15 seconds, depending on the 'length' of the connection).