### PR TITLE
ci(workflows/release): build Linux binaries using manylinux_2_28

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
     name: Build x86_64 Linux binaries
 
     runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_28_x86_64
 
     permissions:
       contents: write


### PR DESCRIPTION
This PR changes the container Linux binaries are built in to `manylinux_2_28` to use an older version of glibc, supporting older/LTS versions of different distributions (RHEL8, etc.)