### PR TITLE
feat: improve throughput by unblocking datagram recv

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,6 +29,9 @@ pub const AUTH_TIMEOUT_MESSAGE: &str = "Authentication timed out";
 /// Buffer size for authentication messages.
 pub const AUTH_MESSAGE_BUFFER_SIZE: usize = 1024;
 
+/// Packet buffer size for operations on the TUN interface.
+pub const PACKET_BUFFER_SIZE: usize = 4;
+
 /// Represents the size of the packet info header on UNIX systems.
 #[cfg(target_os = "macos")]
 pub const DARWIN_PI_HEADER_LENGTH: usize = 4;


### PR DESCRIPTION
This PR improves overall throughput by polling `.read_datagram` as often as possible by writing packets to the TUN interfaces in a separate task running in parallel.

Separating QUIC read/write and TUN read/write leads to the following improvement in performance (MTU 1500 B, latency <1 ms):
**Client -> Server:** 1.5 Gbps -> ~2 Gbps
**Server -> Client:** 1.2 Gbps -> ~1.8 Gbps