### PR TITLE
refactor: migrate to an actively maintained fork of rust-tun

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,35 @@ jobs:
           files: |
             quincy-linux-x86_64.tar.gz
 
+  build-macos-binaries:
+    name: Build arm64 macOS binaries
+
+    runs-on: macos-13
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+      - uses: dtolnay/rust-toolchain@nightly
+        name: Set up toolchain
+      - uses: Swatinem/rust-cache@v2
+        name: Cache toolchain and dependencies
+      - name: Build arm64 macOS binaries
+        run: |
+          cargo build --release
+          mkdir ./quincy-macos-arm64
+          cp target/release/quincy-client quincy-macos-arm64/
+          cp target/release/quincy-server quincy-macos-arm64/
+          cp target/release/quincy-users quincy-macos-arm64/
+          tar zcf quincy-macos-arm64.tar.gz -C quincy-macos-arm64 .
+      - uses: softprops/action-gh-release@v1
+        name: Add binary to release
+        with:
+          files: |
+            quincy-macos-arm64.tar.gz
+
   build-windows-binaries:
     name: Build x86_64 Windows binaries
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
@@ -82,9 +82,9 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "argon2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ba4cac0a46bc1d2912652a751c47f2a9f3a7fe89bcae2275d418f5270402f9"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -172,15 +172,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "bytes"
@@ -225,9 +219,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -235,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -354,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "figment"
-version = "0.10.13"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7629b8c7bcd214a072c2c88b263b5bb3ceb54c34365d8c41c1665461aeae0993"
+checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
 dependencies = [
  "atomic",
  "pear",
@@ -473,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -508,15 +502,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -548,9 +542,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -563,9 +557,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -748,9 +742,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -796,7 +790,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "tun",
+ "tun2",
 ]
 
 [[package]]
@@ -897,13 +891,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -918,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1150,18 +1144,18 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1170,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1208,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -1375,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1396,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "serde",
@@ -1493,12 +1487,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tun"
-version = "0.6.1"
+name = "tun2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adb9992bbd5ca76f3847ed579ad4ee8defb2ec2eea918cceef17ccc66fa4fd4"
+checksum = "b0bc4dcfe2bca93d2acc036d09242ece6a778f807428980586677a8c6c556171"
 dependencies = [
- "byteorder",
  "bytes",
  "futures-core",
  "ioctl-sys",
@@ -1518,9 +1511,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uncased"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
@@ -1569,9 +1562,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1579,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1594,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1604,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1617,15 +1610,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1655,21 +1648,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1806,18 +1799,18 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.33"
+version = "0.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wintun"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b83b0eca06dd125dbcd48a45327c708a6da8aada3d95a3f06db0ce4b17e0d4"
+checksum = "1b3c8c8876c686f8a2d6376999ac1c9a24c74d2968551c9394f7e89127783685"
 dependencies = [
  "c2rust-bitfields",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "quincy"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ path = "src/bin/server.rs"
 name = "quincy-users"
 path = "src/bin/users.rs"
 
+[profile.release]
+strip = true
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+
 [dependencies]
 # Quinn
 quinn = "^0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/bin/users.rs"
 quinn = "^0.10.1"
 
 # Interfaces and networking
-tun = { version = "^0.6.0", features = ["async"] }
+tun2 = { version = "^1.0.0", features = ["async"] }
 socket2 = "^0.5.2"
 bytes = "^1.4"
 etherparse = "^0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quincy"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "MIT"
 description = "QUIC-based VPN"

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -5,7 +5,7 @@ use quincy::config::{ClientConfig, FromPath};
 use quincy::utils::cli::Args;
 use quincy::utils::tracing::enable_tracing;
 use tracing::error;
-use tun::AsyncDevice;
+use tun2::AsyncDevice;
 
 #[tokio::main]
 async fn main() {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -5,7 +5,7 @@ use quincy::server::QuincyServer;
 use quincy::utils::cli::Args;
 use quincy::utils::tracing::enable_tracing;
 use tracing::error;
-use tun::AsyncDevice;
+use tun2::AsyncDevice;
 
 #[tokio::main]
 async fn main() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// Represents a Quincy client that connects to a server and relays packets between the server and a TUN interface.
 pub struct QuincyClient {
@@ -177,19 +177,6 @@ impl QuincyClient {
 
         loop {
             let data = read_interface.read_packet(interface_mtu).await?;
-
-            let quinn_mtu = connection
-                .max_datagram_size()
-                .ok_or_else(|| anyhow!("The Quincy server does not support datagram transfer"))?;
-
-            if data.len() > quinn_mtu {
-                warn!(
-                    "Dropping packet of size {} due to maximum datagram size being {}",
-                    data.len(),
-                    quinn_mtu
-                );
-                continue;
-            }
 
             debug!(
                 "Sending {} bytes to {:?}",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,18 +32,6 @@ pub const AUTH_MESSAGE_BUFFER_SIZE: usize = 1024;
 /// Packet buffer size for operations on the TUN interface.
 pub const PACKET_BUFFER_SIZE: usize = 4;
 
-/// Represents the size of the packet info header on UNIX systems.
-#[cfg(target_os = "macos")]
-pub const DARWIN_PI_HEADER_LENGTH: usize = 4;
-
-/// Represents MacOS packet info header for IPv4
-#[cfg(target_os = "macos")]
-pub const DARWIN_PI_HEADER_IPV4: [u8; 4] = [0_u8, 0_u8, 0_u8, libc::AF_INET as u8];
-
-/// Represents MacOS packet info header for IPv6
-#[cfg(target_os = "macos")]
-pub const DARWIN_PI_HEADER_IPV6: [u8; 4] = [0_u8, 0_u8, 0_u8, libc::AF_INET6 as u8];
-
 /// Represents the supported TLS cipher suites for Quincy.
 pub static QUINCY_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
     rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use bytes::{Bytes, BytesMut};
 use ipnet::IpNet;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
-use tun::{AsyncDevice, Configuration};
+use tun2::{AsyncDevice, Configuration};
 
 pub trait InterfaceRead: AsyncReadExt + Sized + Unpin + Send + 'static {
     #[inline]
@@ -11,22 +11,13 @@ pub trait InterfaceRead: AsyncReadExt + Sized + Unpin + Send + 'static {
         let mut buf = BytesMut::with_capacity(buf_size);
         self.read_buf(&mut buf).await?;
 
-        #[cfg(target_os = "macos")]
-        let data = truncate_packet_info_header(buf.into());
-
-        #[cfg(not(target_os = "macos"))]
-        let data = buf.into();
-
-        Ok(data)
+        Ok(buf.into())
     }
 }
 
 pub trait InterfaceWrite: AsyncWriteExt + Sized + Unpin + Send + 'static {
     #[inline]
     async fn write_packet(&mut self, packet_data: &Bytes) -> Result<()> {
-        #[cfg(target_os = "macos")]
-        let packet_data = &prepend_packet_info_header(packet_data)?;
-
         self.write_all(packet_data).await?;
 
         Ok(())
@@ -43,38 +34,8 @@ pub trait InterfaceWrite: AsyncWriteExt + Sized + Unpin + Send + 'static {
     }
 }
 
-#[cfg(target_os = "macos")]
-#[inline]
-pub fn truncate_packet_info_header(data: Bytes) -> Bytes {
-    use crate::constants::DARWIN_PI_HEADER_LENGTH;
-    data.slice(DARWIN_PI_HEADER_LENGTH..)
-}
-
-#[cfg(target_os = "macos")]
-#[inline]
-pub fn prepend_packet_info_header(data: &Bytes) -> Result<Bytes> {
-    use crate::constants::DARWIN_PI_HEADER_IPV4;
-    use crate::constants::DARWIN_PI_HEADER_IPV6;
-    use anyhow::anyhow;
-    use etherparse::IpHeader;
-    use etherparse::PacketHeaders;
-
-    let packet_headers = PacketHeaders::from_ip_slice(data)?;
-    let ip_header = packet_headers
-        .ip
-        .ok_or_else(|| anyhow!("Received packet with invalid IP header"))?;
-
-    let pi_header = match ip_header {
-        IpHeader::Version4(_, _) => Bytes::from_static(DARWIN_PI_HEADER_IPV4.as_ref()),
-        IpHeader::Version6(_, _) => Bytes::from_static(DARWIN_PI_HEADER_IPV6.as_ref()),
-    };
-
-    // TODO: Do not copy
-    Ok([pi_header.as_ref(), data.as_ref()].concat().into())
-}
-
 pub trait Interface: InterfaceRead + InterfaceWrite {
-    fn create(interface_address: IpNet, mtu: i32) -> Result<Self>;
+    fn create(interface_address: IpNet, mtu: u16) -> Result<Self>;
 }
 
 impl<I: Interface> InterfaceRead for ReadHalf<I> {}
@@ -82,25 +43,20 @@ impl<I: Interface> InterfaceWrite for WriteHalf<I> {}
 impl InterfaceRead for AsyncDevice {}
 impl InterfaceWrite for AsyncDevice {}
 impl Interface for AsyncDevice {
-    fn create(interface_address: IpNet, mtu: i32) -> Result<AsyncDevice> {
+    fn create(interface_address: IpNet, mtu: u16) -> Result<AsyncDevice> {
         let mut config = Configuration::default();
 
         config
             .address(interface_address.addr())
             .netmask(interface_address.netmask())
-            .mtu(mtu)
+            .mtu(mtu as usize)
             .up();
 
         // Needed due to rust-tun using the destination address as the default GW
         #[cfg(not(target_os = "windows"))]
         config.destination(interface_address.network());
 
-        #[cfg(target_os = "linux")]
-        config.platform(|config| {
-            config.packet_information(false);
-        });
-
-        let interface = tun::create_as_async(&config)?;
+        let interface = tun2::create_as_async(&config)?;
 
         Ok(interface)
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -9,7 +9,7 @@ use quinn::Connection;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// Represents a Quincy connection encapsulating authentication and IO.
 #[derive(Clone)]
@@ -103,22 +103,6 @@ impl QuincyConnection {
                 .recv()
                 .await
                 .ok_or(anyhow!("Egress queue has been closed"))?;
-
-            let max_datagram_size = self.connection.max_datagram_size().ok_or(anyhow!(
-                "Client {} failed to provide maximum datagram size",
-                self.client_address()?.addr()
-            ))?;
-
-            debug!("Maximum QUIC datagram size: {max_datagram_size}");
-
-            if data.len() > max_datagram_size {
-                warn!(
-                    "Dropping packet of size {} due to maximum datagram size being {}",
-                    data.len(),
-                    max_datagram_size
-                );
-                continue;
-            }
 
             debug!(
                 "Sending {} bytes to {:?}",

--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -75,7 +75,7 @@ impl QuincyTunnel {
         let interface = I::create(interface_address, self.connection_config.mtu)?;
 
         let (tun_read, tun_write) = tokio::io::split(interface);
-        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (sender, receiver) = mpsc::unbounded_channel();
 
         let quinn_configuration = self
             .tunnel_config

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -81,13 +81,6 @@ pub fn dummy_packet(src: Ipv4Addr, dest: Ipv4Addr) -> Bytes {
         .write(&mut writer, &[1, 2, 3, 4, 5, 6, 7, 8])
         .unwrap();
 
-    #[cfg(target_os = "macos")]
-    {
-        use quincy::interface::prepend_packet_info_header;
-        prepend_packet_info_header(&writer.into_inner().into()).unwrap()
-    }
-
-    #[cfg(not(target_os = "macos"))]
     writer.into_inner().into()
 }
 
@@ -112,7 +105,7 @@ pub const fn make_queue_pair() -> Lazy<(TestSender, TestReceiver)> {
 macro_rules! interface_impl {
     ($name:ident, $test_queue_send:ident, $test_queue_recv:ident) => {
         impl Interface for $name {
-            fn create(_interface_address: IpNet, _mtu: i32) -> Result<Self> {
+            fn create(_interface_address: IpNet, _mtu: u16) -> Result<Self> {
                 Ok(Self::new(
                     $test_queue_send.0.clone(),
                     $test_queue_recv.1.clone(),


### PR DESCRIPTION
This PR:
1. migrates Quincy from https://github.com/meh/rust-tun to https://github.com/ssrlive/rust-tun, an actively maintained fork
2. slightly improves performance on all platforms using a select few compilation parameters
3. adds arm64 MacOS workflows for testing and releasing