### PR TITLE
[#40] fix(config): use correctly derived maximum QUIC overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "quincy"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "etherparse"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827292ea592108849932ad8e30218f8b1f21c0dfd0696698a18b5d0aed62d990"
+checksum = "24890603eb4b43aa788f02261ce21714449033e3e2ab93692f0ab18480c3c9b1"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ quinn = "^0.10.1"
 tun2 = { version = "^1.0.0", features = ["async"] }
 socket2 = "^0.5.2"
 bytes = "^1.4"
-etherparse = "^0.13.0"
+etherparse = "^0.14.0"
 ipnet = "^2.7"
 libc = "^0.2.147"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quincy"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "MIT"
 description = "QUIC-based VPN"

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,9 +48,7 @@ impl QuincyClient {
             interface,
             self.client_config.connection.mtu as usize,
         )
-        .await?;
-
-        Ok(())
+        .await
     }
 
     /// Connects to the Quincy server.

--- a/src/config.rs
+++ b/src/config.rs
@@ -240,8 +240,8 @@ impl ClientConfig {
 
         transport_config.max_idle_timeout(Some(self.connection.timeout.try_into()?));
         transport_config.keep_alive_interval(Some(self.connection.keep_alive_interval));
-        transport_config.initial_mtu(self.connection.mtu);
-        transport_config.min_mtu(self.connection.mtu);
+        transport_config.initial_mtu(self.connection.mtu_with_overhead());
+        transport_config.min_mtu(self.connection.mtu_with_overhead());
 
         quinn_config.transport_config(Arc::new(transport_config));
 
@@ -279,8 +279,8 @@ impl TunnelConfig {
         let mut transport_config = TransportConfig::default();
 
         transport_config.max_idle_timeout(Some(connection_config.timeout.try_into()?));
-        transport_config.initial_mtu(connection_config.mtu);
-        transport_config.min_mtu(connection_config.mtu);
+        transport_config.initial_mtu(connection_config.mtu_with_overhead());
+        transport_config.min_mtu(connection_config.mtu_with_overhead());
 
         quinn_config.transport_config(Arc::new(transport_config));
 
@@ -291,8 +291,12 @@ impl TunnelConfig {
 impl ConnectionConfig {
     pub fn as_endpoint_config(&self) -> Result<EndpointConfig> {
         let mut endpoint_config = EndpointConfig::default();
-        endpoint_config.max_udp_payload_size(self.mtu + QUIC_MTU_OVERHEAD)?;
+        endpoint_config.max_udp_payload_size(self.mtu_with_overhead())?;
 
         Ok(endpoint_config)
+    }
+
+    pub fn mtu_with_overhead(&self) -> u16 {
+        self.mtu + QUIC_MTU_OVERHEAD
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,21 +1,11 @@
-use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
 
 use once_cell::sync::Lazy;
 use quinn::Runtime;
 
-/// Represents the grace interval to add to the auth_timeout variable used for timing out a connection.
-pub const AUTH_TIMEOUT_GRACE: u64 = 5;
-
-/// Represents the size of an `Ipv4Addr` address.
-pub const IPV4_ADDR_SIZE: usize = std::mem::size_of::<Ipv4Addr>();
-
-/// Represents the size of an `Ipv6Addr` address.
-pub const IPV6_ADDR_SIZE: usize = std::mem::size_of::<Ipv6Addr>();
-
-/// Represents the default MTU overhead for QUIC.
-pub const QUIC_MTU_OVERHEAD: u16 = 42;
+/// Represents the maximum MTU overhead for QUIC, since the QUIC header is variable in size.
+pub const QUIC_MTU_OVERHEAD: u16 = 50;
 
 /// Represents the interval used by various cleanup tasks.
 pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(1);

--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -10,7 +10,7 @@ use crate::utils::socket::bind_socket;
 use anyhow::Result;
 use bytes::Bytes;
 use dashmap::DashMap;
-use etherparse::{IpHeader, PacketHeaders};
+use etherparse::{NetHeaders, PacketHeaders};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use ipnet::Ipv4Net;
@@ -224,17 +224,17 @@ impl QuincyTunnel {
                 }
             };
 
-            let ip_header = match headers.ip {
-                Some(ip_header) => ip_header,
+            let net_header = match headers.net {
+                Some(net) => net,
                 None => {
                     warn!("Received a packet with invalid IP header");
                     continue;
                 }
             };
 
-            let dest_addr: IpAddr = match ip_header {
-                IpHeader::Version4(header, _) => header.destination.into(),
-                IpHeader::Version6(header, _) => header.destination.into(),
+            let dest_addr: IpAddr = match net_header {
+                NetHeaders::Ipv4(header, _) => header.destination.into(),
+                NetHeaders::Ipv6(header, _) => header.destination.into(),
             };
             debug!("Destination address for packet: {dest_addr}");
 


### PR DESCRIPTION
This PR increases the maximum possible QUIC overhead to a correct value.