### PR TITLE
[#46] fix(client, server): correctly log errors during config/app init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "quincy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quincy"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "MIT"
 description = "QUIC-based VPN"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  # Ignore all app entrypoints because they are not unit/integration tested
+  - "src/bin"

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,26 +1,34 @@
+use std::process::exit;
+
 use anyhow::Result;
 use clap::Parser;
 use quincy::client::QuincyClient;
 use quincy::config::{ClientConfig, FromPath};
 use quincy::utils::cli::Args;
-use quincy::utils::tracing::enable_tracing;
+use quincy::utils::tracing::log_subscriber;
 use tracing::error;
 use tun2::AsyncDevice;
 
 #[tokio::main]
 async fn main() {
-    let args: Args = Args::parse();
+    // Enable default tracing to log errors before the configuration is loaded.
+    let _logger = tracing::subscriber::set_default(log_subscriber("info"));
 
-    match run_client(args).await {
+    match run_client().await {
         Ok(_) => {}
-        Err(e) => error!("A critical error occurred: {e}"),
+        Err(e) => {
+            error!("A critical error occurred: {e}");
+            exit(1);
+        }
     }
 }
 
 /// Runs the Quincy client.
-async fn run_client(args: Args) -> Result<()> {
+async fn run_client() -> Result<()> {
+    let args = Args::try_parse()?;
     let config = ClientConfig::from_path(&args.config_path, &args.env_prefix)?;
-    enable_tracing(&config.log.level);
+    // Enable tracing with the log level from the configuration.
+    tracing::subscriber::set_global_default(log_subscriber(&config.log.level))?;
 
     let client = QuincyClient::new(config);
     client.run::<AsyncDevice>().await

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,26 +1,34 @@
+use std::process::exit;
+
 use anyhow::Result;
 use clap::Parser;
 use quincy::config::{FromPath, ServerConfig};
 use quincy::server::QuincyServer;
 use quincy::utils::cli::Args;
-use quincy::utils::tracing::enable_tracing;
+use quincy::utils::tracing::log_subscriber;
 use tracing::error;
 use tun2::AsyncDevice;
 
 #[tokio::main]
 async fn main() {
-    let args: Args = Args::parse();
+    // Enable default tracing to log errors before the configuration is loaded.
+    let _logger = tracing::subscriber::set_default(log_subscriber("info"));
 
-    match run_server(args).await {
+    match run_server().await {
         Ok(_) => {}
-        Err(e) => error!("A critical error occurred: {e}"),
+        Err(e) => {
+            error!("A critical error occurred: {e}");
+            exit(1)
+        }
     }
 }
 
 /// Runs the Quincy server.
-async fn run_server(args: Args) -> Result<()> {
+async fn run_server() -> Result<()> {
+    let args = Args::try_parse()?;
     let config = ServerConfig::from_path(&args.config_path, &args.env_prefix)?;
-    enable_tracing(&config.log.level);
+    // Enable tracing with the log level from the configuration.
+    tracing::subscriber::set_global_default(log_subscriber(&config.log.level))?;
 
     let server = QuincyServer::new(config)?;
     server.run::<AsyncDevice>().await

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,12 @@ pub trait FromPath<T: DeserializeOwned + ConfigInit<T>> {
     /// - `path` - a path to the configuration file
     /// - `env_prefix` - the ENV prefix to use for overrides
     fn from_path(path: &Path, env_prefix: &str) -> Result<T> {
+        if !path.exists() {
+            return Err(anyhow::anyhow!(
+                "configuration file {path:?} does not exist or cannot be read"
+            ));
+        }
+
         let figment = Figment::new()
             .merge(Toml::file(path))
             .merge(Env::prefixed(env_prefix));

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -1,15 +1,15 @@
+use tracing::Subscriber;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
 
-/// Enables tracing for the application.
+/// Returns a new `tracing` subscriber with the specified log level.
 ///
 /// ### Arguments
 /// - `log_level` - the log level to use
-pub fn enable_tracing(log_level: &str) {
+pub fn log_subscriber(log_level: &str) -> impl Subscriber {
     let registry = tracing_subscriber::Registry::default();
     let fmt_layer = tracing_subscriber::fmt::Layer::new();
     let filter_layer = EnvFilter::try_new(log_level).unwrap();
 
-    let subscriber = registry.with(filter_layer).with(fmt_layer);
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    registry.with(filter_layer).with(fmt_layer)
 }


### PR DESCRIPTION
This PR fixes #46, which was caused by the lack of tracing subscriber initialization before the configuration files were loaded.