### PR TITLE
[#52] fix(server): do not crash during unsuccessful handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "quincy"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quincy"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "MIT"
 description = "QUIC-based VPN"


### PR DESCRIPTION
This PR fixes an issue where the entire server-side of Quincy would crash due to an unsuccessful handshake with a client.