### PR TITLE
feat: add configurable client isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "argon2"
@@ -100,13 +100,13 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -189,9 +189,9 @@ checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "bytes"
@@ -239,9 +239,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "figment"
-version = "0.10.14"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+checksum = "7270677e7067213e04f323b55084586195f18308cd7546cfac9f873344ccceb6"
 dependencies = [
  "atomic",
  "pear",
@@ -436,7 +436,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -516,9 +516,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -765,7 +765,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -794,9 +794,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -809,7 +809,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "version_check",
  "yansi",
 ]
@@ -1059,7 +1059,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.52",
+ "syn 2.0.53",
  "unicode-ident",
 ]
 
@@ -1214,7 +1214,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1328,22 +1328,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap",
  "serde",
@@ -1487,7 +1487,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1649,7 +1649,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -1671,7 +1671,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1889,6 +1889,6 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2861d76f58ec8fc95708b9b1e417f7b12fd72ad33c01fa6886707092dea0d3"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,16 +27,19 @@ pub struct ServerConfig {
     pub certificate_file: PathBuf,
     /// The certificate private key to use for the tunnel
     pub certificate_key_file: PathBuf,
-    /// The address to bind the tunnel to
+    /// The address to bind the tunnel to (default = 0.0.0.0)
     #[serde(default = "default_bind_address")]
     pub bind_address: IpAddr,
-    /// The port to bind the tunnel to
+    /// The port to bind the tunnel to (default = 55555)
     #[serde(default = "default_bind_port")]
     pub bind_port: u16,
     /// The address of this tunnel
     pub address_tunnel: Ipv4Addr,
     /// The address mask for this tunnel
     pub address_mask: Ipv4Addr,
+    /// Whether to isolate clients from each other (default = true)
+    #[serde(default = "default_true_fn")]
+    pub isolate_clients: bool,
     /// Authentication configuration
     pub authentication: ServerAuthenticationConfig,
     /// Miscellaneous connection configuration
@@ -48,7 +51,7 @@ pub struct ServerConfig {
 /// Represents the configuration for a Quincy server's authentication.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ServerAuthenticationConfig {
-    /// The type of authenticator to use
+    /// The type of authenticator to use (default = users_file)
     #[serde(default = "default_auth_type")]
     pub auth_type: AuthType,
     /// The path to the file containing the list of users and their password hashes
@@ -71,7 +74,7 @@ pub struct ClientConfig {
 /// Represents the configuration for a Quincy client's authentication.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ClientAuthenticationConfig {
-    /// The type of authenticator to use
+    /// The type of authenticator to use (default = users_file)
     #[serde(default = "default_auth_type")]
     pub auth_type: AuthType,
     /// The username to use for authentication
@@ -85,19 +88,19 @@ pub struct ClientAuthenticationConfig {
 /// Represents miscellaneous connection configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ConnectionConfig {
-    /// The MTU to use for connections and the TUN interface
+    /// The MTU to use for connections and the TUN interface (default = 1400)
     #[serde(default = "default_mtu")]
     pub mtu: u16,
-    /// The time after which a connection is considered timed out
+    /// The time after which a connection is considered timed out (default = 30s)
     #[serde(default = "default_timeout")]
     pub connection_timeout: Duration,
-    /// Keep alive interval for connections
+    /// Keep alive interval for connections (default = 25s)
     #[serde(default = "default_keep_alive_interval")]
     pub keep_alive_interval: Duration,
-    /// The size of the send buffer of the socket and Quinn endpoint
+    /// The size of the send buffer of the socket and Quinn endpoint (default = 2097152)
     #[serde(default = "default_buffer_size")]
     pub send_buffer_size: u64,
-    /// The size of the receive buffer of the socket and Quinn endpoint
+    /// The size of the receive buffer of the socket and Quinn endpoint (default = 2097152)
     #[serde(default = "default_buffer_size")]
     pub recv_buffer_size: u64,
 }
@@ -105,7 +108,7 @@ pub struct ConnectionConfig {
 /// Represents logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct LogConfig {
-    /// The log level to use
+    /// The log level to use (default = info)
     #[serde(default = "default_log_level")]
     pub level: String,
 }
@@ -182,6 +185,10 @@ fn default_keep_alive_interval() -> Duration {
 
 fn default_auth_type() -> AuthType {
     AuthType::UsersFile
+}
+
+fn default_true_fn() -> bool {
+    true
 }
 
 impl ClientConfig {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,7 +12,6 @@ use crate::utils::socket::bind_socket;
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use dashmap::DashMap;
-use etherparse::{NetHeaders, PacketHeaders};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use ipnet::Ipv4Net;
@@ -20,7 +19,7 @@ use quinn::{Endpoint, VarInt};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::constants::{PACKET_BUFFER_SIZE, PACKET_CHANNEL_SIZE, QUINN_RUNTIME};
-use crate::interface::{Interface, InterfaceRead, InterfaceWrite};
+use crate::interface::{Interface, InterfaceRead, InterfaceWrite, Packet};
 use crate::utils::tasks::abort_all;
 use tracing::{debug, info, warn};
 
@@ -54,7 +53,7 @@ impl QuincyServer {
     }
 
     /// Starts the tasks for this instance of Quincy tunnel and listens for incoming connections.
-    pub async fn run<I: Interface>(self) -> Result<()> {
+    pub async fn run<I: Interface>(&self) -> Result<()> {
         let interface_address =
             Ipv4Net::with_netmask(self.config.address_tunnel, self.config.address_mask)?.into();
 
@@ -76,7 +75,12 @@ impl QuincyServer {
                 self.connection_queues.clone(),
                 self.config.connection.mtu as usize,
             )),
-            tokio::spawn(Self::process_inbound_traffic(tun_write, receiver)),
+            tokio::spawn(Self::process_inbound_traffic(
+                self.connection_queues.clone(),
+                tun_write,
+                receiver,
+                self.config.isolate_clients,
+            )),
         ]);
 
         let handler_task = self.handle_connections(auth_server, sender);
@@ -99,7 +103,7 @@ impl QuincyServer {
     async fn handle_connections(
         &self,
         auth_server: AuthServer,
-        ingress_queue: Sender<Bytes>,
+        ingress_queue: Sender<Packet>,
     ) -> Result<()> {
         let endpoint = self.create_quinn_endpoint()?;
 
@@ -218,60 +222,96 @@ impl QuincyServer {
         debug!("Started tunnel outbound traffic task (interface -> connection queue)");
 
         loop {
-            let buf = tun_read.read_packet(buffer_size).await?;
-
-            let headers = match PacketHeaders::from_ip_slice(&buf) {
-                Ok(headers) => headers,
+            let packet = tun_read.read_packet(buffer_size).await?;
+            let dest_addr = match packet.destination() {
+                Ok(addr) => addr,
                 Err(e) => {
-                    warn!("Failed to parse IP packet: {e}");
+                    warn!("Received packet with malformed header structure: {e}");
                     continue;
                 }
             };
 
-            let net_header = match headers.net {
-                Some(net) => net,
-                None => {
-                    warn!("Received a packet with invalid IP header");
-                    continue;
-                }
-            };
-
-            let dest_addr: IpAddr = match net_header {
-                NetHeaders::Ipv4(header, _) => header.destination.into(),
-                NetHeaders::Ipv6(header, _) => header.destination.into(),
-            };
             debug!("Destination address for packet: {dest_addr}");
 
             let connection_queue = match connection_queues.get(&dest_addr) {
                 Some(connection_queue) => connection_queue,
                 None => continue,
             };
+
             debug!("Found connection for IP {dest_addr}");
 
-            connection_queue.send(buf).await?;
+            connection_queue.send(packet.into()).await?;
         }
     }
 
     /// Reads data from the QUIC connection and sends it to the TUN interface worker.
     ///
     /// ### Arguments
+    /// - `connection_queues` - the queues for sending data to the QUIC connections
     /// - `tun_write` - the write half of the TUN interface
     /// - `ingress_queue` - the queue for sending data to the TUN interface
     async fn process_inbound_traffic(
-        mut tun_write: impl InterfaceWrite,
-        mut ingress_queue: Receiver<Bytes>,
+        connection_queues: ConnectionQueues,
+        tun_write: impl InterfaceWrite,
+        ingress_queue: Receiver<Packet>,
+        isolate_clients: bool,
     ) -> Result<()> {
         debug!("Started tunnel inbound traffic task (tunnel queue -> interface)");
 
-        let mut packets = Vec::with_capacity(PACKET_BUFFER_SIZE);
+        if isolate_clients {
+            relay_isolated(tun_write, ingress_queue).await
+        } else {
+            relay_unisolated(connection_queues, tun_write, ingress_queue).await
+        }
+    }
+}
 
-        loop {
-            packets.clear();
-            ingress_queue
-                .recv_many(&mut packets, PACKET_BUFFER_SIZE)
-                .await;
+#[inline]
+async fn relay_isolated(
+    mut tun_write: impl InterfaceWrite,
+    mut ingress_queue: Receiver<Packet>,
+) -> Result<()> {
+    let mut packets = Vec::with_capacity(PACKET_BUFFER_SIZE);
 
-            tun_write.write_packets(&packets).await?;
+    loop {
+        packets.clear();
+        ingress_queue
+            .recv_many(&mut packets, PACKET_BUFFER_SIZE)
+            .await;
+
+        tun_write.write_packets(&packets).await?;
+    }
+}
+
+#[inline]
+async fn relay_unisolated(
+    connection_queues: ConnectionQueues,
+    mut tun_write: impl InterfaceWrite,
+    mut ingress_queue: Receiver<Packet>,
+) -> Result<()> {
+    let mut packets = Vec::with_capacity(PACKET_BUFFER_SIZE);
+
+    loop {
+        packets.clear();
+        ingress_queue
+            .recv_many(&mut packets, PACKET_BUFFER_SIZE)
+            .await;
+
+        for packet in &packets {
+            let dest_addr = match packet.destination() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    warn!("Received packet with malformed header structure: {e}");
+                    continue;
+                }
+            };
+
+            match connection_queues.get(&dest_addr) {
+                // Send the packet to the appropriate QUIC connection
+                Some(connection_queue) => connection_queue.send(packet.clone().into()).await?,
+                // Send the packet to the TUN interface
+                None => tun_write.write_packet(packet).await?,
+            }
         }
     }
 }

--- a/tests/test_client_communication.rs
+++ b/tests/test_client_communication.rs
@@ -1,0 +1,86 @@
+use std::net::Ipv4Addr;
+
+use anyhow::Result;
+use common::{
+    client_config, make_queue_pair, server_config, TestInterface, TestReceiver, TestSender,
+};
+use ipnet::IpNet;
+use once_cell::sync::Lazy;
+use quincy::{
+    client::QuincyClient,
+    config::{ClientConfig, ServerConfig},
+    interface::Interface,
+    server::QuincyServer,
+};
+use rstest::rstest;
+
+use crate::common::dummy_packet;
+
+mod common;
+
+struct ClientA;
+type ClientAInterface = TestInterface<ClientA>;
+struct ClientB;
+type ClientBInterface = TestInterface<ClientB>;
+struct Server;
+type ServerInterface = TestInterface<Server>;
+
+pub static TEST_QUEUE_CLIENT_A_SEND: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_CLIENT_A_RECV: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_CLIENT_B_SEND: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_CLIENT_B_RECV: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_SERVER_SEND: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_SERVER_RECV: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+
+interface_impl!(
+    ClientAInterface,
+    TEST_QUEUE_CLIENT_A_SEND,
+    TEST_QUEUE_CLIENT_A_RECV
+);
+interface_impl!(
+    ClientBInterface,
+    TEST_QUEUE_CLIENT_B_SEND,
+    TEST_QUEUE_CLIENT_B_RECV
+);
+interface_impl!(
+    ServerInterface,
+    TEST_QUEUE_SERVER_SEND,
+    TEST_QUEUE_SERVER_RECV
+);
+
+#[rstest]
+#[tokio::test]
+async fn test_client_communication(client_config: ClientConfig, mut server_config: ServerConfig) {
+    server_config.isolate_clients = false;
+
+    let client_a = QuincyClient::new(client_config.clone());
+    let client_b = QuincyClient::new(client_config);
+    let server = QuincyServer::new(server_config).unwrap();
+
+    let ip_client_a = Ipv4Addr::new(10, 0, 0, 2);
+    let ip_client_b = Ipv4Addr::new(10, 0, 0, 3);
+
+    tokio::spawn(async move { server.run::<ServerInterface>().await.unwrap() });
+    tokio::spawn(async move { client_a.run::<ClientAInterface>().await.unwrap() });
+    tokio::spawn(async move { client_b.run::<ClientBInterface>().await.unwrap() });
+
+    // Test client A -> client B
+    let test_packet = dummy_packet(ip_client_a, ip_client_b);
+
+    TEST_QUEUE_CLIENT_A_RECV
+        .0
+        .lock()
+        .await
+        .send(test_packet.clone())
+        .unwrap();
+
+    let recv_packet = TEST_QUEUE_CLIENT_B_SEND
+        .1
+        .lock()
+        .await
+        .recv()
+        .await
+        .unwrap();
+
+    assert_eq!(recv_packet, test_packet);
+}

--- a/tests/test_client_isolation.rs
+++ b/tests/test_client_isolation.rs
@@ -1,0 +1,80 @@
+use std::{net::Ipv4Addr, time::Duration};
+
+use anyhow::Result;
+use common::{
+    client_config, make_queue_pair, server_config, TestInterface, TestReceiver, TestSender,
+};
+use ipnet::IpNet;
+use once_cell::sync::Lazy;
+use quincy::{
+    client::QuincyClient,
+    config::{ClientConfig, ServerConfig},
+    interface::Interface,
+    server::QuincyServer,
+};
+use rstest::rstest;
+use tokio::time::timeout;
+
+use crate::common::dummy_packet;
+
+mod common;
+
+struct ClientA;
+type ClientAInterface = TestInterface<ClientA>;
+struct ClientB;
+type ClientBInterface = TestInterface<ClientB>;
+struct Server;
+type ServerInterface = TestInterface<Server>;
+
+pub static TEST_QUEUE_CLIENT_A_SEND: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_CLIENT_A_RECV: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_CLIENT_B_SEND: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_CLIENT_B_RECV: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_SERVER_SEND: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+pub static TEST_QUEUE_SERVER_RECV: Lazy<(TestSender, TestReceiver)> = make_queue_pair();
+
+interface_impl!(
+    ClientAInterface,
+    TEST_QUEUE_CLIENT_A_SEND,
+    TEST_QUEUE_CLIENT_A_RECV
+);
+interface_impl!(
+    ClientBInterface,
+    TEST_QUEUE_CLIENT_B_SEND,
+    TEST_QUEUE_CLIENT_B_RECV
+);
+interface_impl!(
+    ServerInterface,
+    TEST_QUEUE_SERVER_SEND,
+    TEST_QUEUE_SERVER_RECV
+);
+
+#[rstest]
+#[tokio::test]
+async fn test_client_isolation(client_config: ClientConfig, server_config: ServerConfig) {
+    let client_a = QuincyClient::new(client_config.clone());
+    let client_b = QuincyClient::new(client_config);
+    let server = QuincyServer::new(server_config).unwrap();
+
+    let ip_client_a = Ipv4Addr::new(10, 0, 0, 2);
+    let ip_client_b = Ipv4Addr::new(10, 0, 0, 3);
+
+    tokio::spawn(async move { server.run::<ServerInterface>().await.unwrap() });
+    tokio::spawn(async move { client_a.run::<ClientAInterface>().await.unwrap() });
+    tokio::spawn(async move { client_b.run::<ClientBInterface>().await.unwrap() });
+
+    // Test client A -> client B
+    let test_packet = dummy_packet(ip_client_a, ip_client_b);
+
+    TEST_QUEUE_CLIENT_A_RECV
+        .0
+        .lock()
+        .await
+        .send(test_packet.clone())
+        .unwrap();
+
+    let mut recv_queue = TEST_QUEUE_CLIENT_B_SEND.1.lock().await;
+
+    let recv_result = timeout(Duration::from_secs(1), recv_queue.recv()).await;
+    assert!(recv_result.is_err());
+}


### PR DESCRIPTION
This PR adds configurable client isolation.

To keep the behaviour the same, and due to some security concerns, the default is **disabled**. It can be enabled in the server configuration file by changing `isolate_clients` to `false`.

Closes #41.
Closes #56.

