### PR TITLE
feat!: add support for client-side route configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,33 +43,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -101,13 +101,13 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -184,9 +184,9 @@ checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "c2rust-bitfields"
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.105"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cesu8"
@@ -234,9 +234,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -256,27 +256,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "combine"
@@ -448,7 +448,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -629,9 +629,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -679,13 +679,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -712,11 +713,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -754,20 +755,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -834,7 +825,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -887,14 +878,14 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "quincy"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -908,7 +899,7 @@ dependencies = [
  "ipnet",
  "jemallocator",
  "libc",
- "nu-ansi-term 0.50.0",
+ "nu-ansi-term 0.50.1",
  "once_cell",
  "quinn",
  "rpassword",
@@ -963,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
@@ -1015,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
@@ -1124,7 +1115,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.69",
+ "syn 2.0.72",
  "unicode-ident",
 ]
 
@@ -1161,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "ring",
@@ -1231,9 +1222,9 @@ checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1272,9 +1263,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1286,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1317,7 +1308,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1333,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -1414,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.69"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1425,22 +1416,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1474,9 +1465,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinyvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6b6a2fb3a985e99cebfaefa9faa3024743da73304ca1c683a36429613d3d22"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1489,31 +1480,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1531,21 +1521,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.17",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
@@ -1563,15 +1553,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.16",
 ]
 
 [[package]]
@@ -1594,7 +1584,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1654,14 +1644,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "tun2"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa430061b1bfcc7b0e22931aa706f3f20471aeb13346eceec4071a0191fca20"
+checksum = "50ff242bea1c5ceb9b6aa4918cf340a6c157e1328a2389c5353cf91049d8cf17"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1719,9 +1709,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1778,25 +1768,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1948,24 +1919,24 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wintun"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3c8c8876c686f8a2d6376999ac1c9a24c74d2968551c9394f7e89127783685"
+checksum = "b196f9328341b035820c54beebca487823e2e20a5977f284f2af2a0ee8f04400"
 dependencies = [
  "c2rust-bitfields",
  "libloading",
  "log",
  "thiserror",
- "windows",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,9 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tun2 = { version = "^2.0.0", features = ["async"] }
 socket2 = "^0.5.2"
 bytes = "^1.4"
 etherparse = "^0.15.0"
-ipnet = "^2.7"
+ipnet = { version = "^2.7", features = ["serde"] }
 libc = "^0.2.147"
 
 # Tokio

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quincy"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "MIT"
 description = "QUIC-based VPN"

--- a/examples/client.toml
+++ b/examples/client.toml
@@ -13,6 +13,12 @@ trusted_certificates = ["examples/cert/ca_cert.pem"]
 # The MTU used by the QUIC tunnel and the spawned TUN interface
 mtu = 1400
 
+[network]
+routes = [
+    "10.0.1.0/24",
+    "10.11.12.0/24"
+]
+
 [log]
 # The log level
 level = "info"

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -5,9 +5,7 @@ certificate_file = "examples/cert/server_cert.pem"
 # Path to the certificate key used for TLS
 certificate_key_file = "examples/cert/server_key.pem"
 # The address of the tunnel endpoint and base address of the address pool available to clients
-address_tunnel = "10.0.0.1"
-# Netmask used to generate the address pool available to clients
-address_mask = "255.255.255.0"
+tunnel_network = "10.0.0.1/24"
 
 [authentication]
 # Path to the file containing user credentials

--- a/src/auth/stream.rs
+++ b/src/auth/stream.rs
@@ -1,7 +1,8 @@
-use std::{net::IpAddr, time::Duration};
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use bytes::BytesMut;
+use ipnet::IpNet;
 use quinn::{Connection, RecvStream, SendStream};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,8 +13,13 @@ use crate::constants::AUTH_MESSAGE_BUFFER_SIZE;
 /// Represents an authentication message sent between the client and the server.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AuthMessage {
-    Authenticate(Value),
-    Authenticated(IpAddr, IpAddr),
+    Authenticate {
+        payload: Value,
+    },
+    Authenticated {
+        client_address: IpNet,
+        server_address: IpNet,
+    },
     Failed,
 }
 

--- a/src/auth/users_file.rs
+++ b/src/auth/users_file.rs
@@ -69,7 +69,7 @@ impl ServerAuthenticator for UsersFileServerAuthenticator {
         &self,
         address_pool: &AddressPool,
         authentication_payload: Value,
-    ) -> anyhow::Result<(String, IpNet)> {
+    ) -> Result<(String, IpNet)> {
         let payload: UsersFilePayload = serde_json::from_value(authentication_payload)
             .context("failed to parse UsersFilePayload")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod certificates;
 pub mod client;
 pub mod config;
 pub mod constants;
-pub mod interface;
+pub mod network;
 pub mod server;
 pub mod socket;
 pub mod utils;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,3 @@
+pub mod interface;
+pub mod packet;
+pub mod route;

--- a/src/network/packet.rs
+++ b/src/network/packet.rs
@@ -1,0 +1,46 @@
+use anyhow::{anyhow, Context};
+use bytes::{Bytes, BytesMut};
+use etherparse::{NetHeaders, PacketHeaders};
+use std::net::IpAddr;
+
+/// Structure encapsulating a network packet (its data) with additional metadata parsed from the packet.
+#[derive(Debug, Clone)]
+pub struct Packet {
+    pub data: Bytes,
+}
+
+impl Packet {
+    pub fn new(data: Bytes) -> Self {
+        Self { data }
+    }
+
+    /// Returns the destination IP address of the packet.
+    pub fn destination(&self) -> anyhow::Result<IpAddr> {
+        let headers =
+            PacketHeaders::from_ip_slice(&self.data).context("failed to parse IP packet")?;
+        let net_header = headers.net.ok_or(anyhow!("no network header"))?;
+
+        match net_header {
+            NetHeaders::Ipv4(header, _) => Ok(header.destination.into()),
+            NetHeaders::Ipv6(header, _) => Ok(header.destination.into()),
+        }
+    }
+}
+
+impl From<BytesMut> for Packet {
+    fn from(data: BytesMut) -> Self {
+        Self::new(data.freeze())
+    }
+}
+
+impl From<Bytes> for Packet {
+    fn from(data: Bytes) -> Self {
+        Self::new(data)
+    }
+}
+
+impl From<Packet> for Bytes {
+    fn from(packet: Packet) -> Self {
+        packet.data
+    }
+}

--- a/src/network/route.rs
+++ b/src/network/route.rs
@@ -1,0 +1,44 @@
+use anyhow::{anyhow, Context, Result};
+use ipnet::IpNet;
+use std::net::IpAddr;
+use std::process::Command;
+
+#[cfg(target_os = "linux")]
+const ROUTE_ADD_COMMAND: &str = "route add -net {network} netmask {netmask} gw {gateway}";
+#[cfg(target_os = "windows")]
+const ROUTE_ADD_COMMAND: &str = "route add {network} mask {netmask} {gateway}";
+#[cfg(target_os = "macos")]
+const ROUTE_ADD_COMMAND: &str = "route -n add -net {network} -netmask {netmask} {gateway}";
+#[cfg(target_os = "freebsd")]
+const ROUTE_ADD_COMMAND: &str = "route add -net {network} -netmask {netmask} {gateway}";
+
+/// Adds a route to the routing table.
+///
+/// ### Arguments
+/// - `network` - the network to add the route for
+/// - `gateway` - the gateway to use for the route
+pub fn add_route(network: &IpNet, gateway: &IpAddr) -> Result<()> {
+    let route_add_command = ROUTE_ADD_COMMAND
+        .replace("{network}", &network.addr().to_string())
+        .replace("{netmask}", &network.netmask().to_string())
+        .replace("{gateway}", &gateway.to_string());
+
+    let route_command_split = route_add_command.split(" ").collect::<Vec<_>>();
+
+    let route_program = route_command_split[0];
+    let route_args = &route_command_split[1..];
+
+    let output = Command::new(route_program)
+        .args(route_args)
+        .output()
+        .context("failed to execute route command")?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "failed to add route: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,10 +1,11 @@
-use crate::{auth::server::AuthServer, interface::Packet, utils::tasks::abort_all};
+use crate::{auth::server::AuthServer, utils::tasks::abort_all};
 use anyhow::{anyhow, Error, Result};
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use ipnet::IpNet;
 
+use crate::network::packet::Packet;
 use quinn::Connection;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::info;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use etherparse::PacketBuilder;
 use once_cell::sync::Lazy;
 use quincy::config::{ClientConfig, FromPath, ServerConfig};
-use quincy::interface::{InterfaceRead, InterfaceWrite};
+use quincy::network::interface::{InterfaceRead, InterfaceWrite};
 use rstest::fixture;
 use std::io::Error;
 use std::net::Ipv4Addr;

--- a/tests/static/server.toml
+++ b/tests/static/server.toml
@@ -1,8 +1,7 @@
 name = "tun0"
 certificate_file = "tests/static/cert.pem"
 certificate_key_file = "tests/static/key.pem"
-address_tunnel = "10.0.0.1"
-address_mask = "255.255.255.0"
+tunnel_network = "10.0.0.1/24"
 bind_address = "::"
 bind_port = 55155
 

--- a/tests/test_client_communication.rs
+++ b/tests/test_client_communication.rs
@@ -1,20 +1,19 @@
 use std::net::Ipv4Addr;
 
+use crate::common::dummy_packet;
 use anyhow::Result;
 use common::{
     client_config, make_queue_pair, server_config, TestInterface, TestReceiver, TestSender,
 };
 use ipnet::IpNet;
 use once_cell::sync::Lazy;
+use quincy::network::interface::Interface;
 use quincy::{
     client::QuincyClient,
     config::{ClientConfig, ServerConfig},
-    interface::Interface,
     server::QuincyServer,
 };
 use rstest::rstest;
-
-use crate::common::dummy_packet;
 
 mod common;
 

--- a/tests/test_client_isolation.rs
+++ b/tests/test_client_isolation.rs
@@ -1,21 +1,20 @@
 use std::{net::Ipv4Addr, time::Duration};
 
+use crate::common::dummy_packet;
 use anyhow::Result;
 use common::{
     client_config, make_queue_pair, server_config, TestInterface, TestReceiver, TestSender,
 };
 use ipnet::IpNet;
 use once_cell::sync::Lazy;
+use quincy::network::interface::Interface;
 use quincy::{
     client::QuincyClient,
     config::{ClientConfig, ServerConfig},
-    interface::Interface,
     server::QuincyServer,
 };
 use rstest::rstest;
 use tokio::time::timeout;
-
-use crate::common::dummy_packet;
 
 mod common;
 

--- a/tests/test_end_to_end.rs
+++ b/tests/test_end_to_end.rs
@@ -7,7 +7,7 @@ use ipnet::IpNet;
 use once_cell::sync::Lazy;
 use quincy::client::QuincyClient;
 use quincy::config::{ClientConfig, ServerConfig};
-use quincy::interface::Interface;
+use quincy::network::interface::Interface;
 use quincy::server::QuincyServer;
 use rstest::rstest;
 use std::net::Ipv4Addr;

--- a/tests/test_failed_auth.rs
+++ b/tests/test_failed_auth.rs
@@ -7,7 +7,7 @@ use ipnet::IpNet;
 use once_cell::sync::Lazy;
 use quincy::client::QuincyClient;
 use quincy::config::{ClientConfig, ServerConfig};
-use quincy::interface::Interface;
+use quincy::network::interface::Interface;
 use quincy::server::QuincyServer;
 use rstest::rstest;
 use std::net::Ipv4Addr;


### PR DESCRIPTION
This PR adds support for client-side route configuration using a new configuration section, `network`:
```toml
[network]
routes = [
    "10.1.2.0/24",
    "10.11.12.0/24"
]
```

It also replaces the `address_tunnel` and `address_mask` config attributes with a `tunnel_network` attribute combining the two, using the `<address>/<netmask>` format.

Closes #77.