### PR TITLE
fix: document/remove issues with capabilities and DNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,17 @@ RUN apk add gcompat jemalloc libcap-setcap
 # Copy the binary from the builder stage
 COPY --from=builder /tmp/quincy-build/target/release/quincy-client /tmp/quincy-build/target/release/quincy-server /tmp/quincy-build/target/release/quincy-users /usr/local/bin/
 
-# Add required capability to executable
+# Add a non-root user
+RUN addgroup -S quincy && adduser -S quincy -G quincy
+RUN chown -R quincy:quincy /usr/local/bin/quincy-client /usr/local/bin/quincy-server /usr/local/bin/quincy-users
+
+# Add required capabilities to executables
 RUN setcap \
-    'cap_net_admin=+ep cap_net_bind_service=+ep' /usr/local/bin/quincy-client \
-    'cap_net_admin=+ep cap_net_bind_service=+ep' /usr/local/bin/quincy-server
+    'cap_net_admin,cap_net_bind_service=+ep' /usr/local/bin/quincy-client \
+    'cap_net_admin,cap_net_bind_service=+ep' /usr/local/bin/quincy-server \
+    'cap_net_admin=+ep' /bin/busybox
 
 # Run under a non-root account
-RUN addgroup -S quincy && adduser -S quincy -G quincy
 USER quincy
 
 # Set the working directory

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Docker images are available on [Docker Hub](https://hub.docker.com/r/m0dex/quinc
 - `m0dex/quincy:<version>`: A specific version of Quincy with pre-quantum cryptography
 - `m0dex/quincy:<version>-quantum`: A specific version of Quincy with post-quantum cryptography
 
+**Note: it is not possible to use the `dns_servers` configuration option due to how Docker networking works**
+
 To run the client/server, you need to add a volume with the configuration files and add needed capabilities:
 ```bash
 docker run

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,5 @@ ignore:
   - "src/bin"
   # Ignore all network related code because it cannot be unit/integration tested in CI
   - "src/network"
+  # Command utilities
+  - "src/utils/command"

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -8,6 +8,7 @@ pub fn run_command<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
 ) -> Result<Child> {
     Command::new(program)
         .args(arguments)
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
         .context("failed to execute command")


### PR DESCRIPTION
Remove issues with capabilities of `/bin/busybox` when setting routes.

Document issues with DNS servers due to Docker incompatibilities.

Closes #107.