### PR TITLE
fix: restrict access to GUI IPC on Windows

### DIFF
--- a/quincy-gui/src/ipc.rs
+++ b/quincy-gui/src/ipc.rs
@@ -116,6 +116,8 @@ impl IpcServer {
         {
             let server = ServerOptions::new()
                 .first_pipe_instance(true)
+                .access_inbound(true)
+                .reject_remote_clients(true)
                 .create(&self.pipe_path)?;
             server.connect().await?;
             Ok(IpcConnection::new_windows_server(server))


### PR DESCRIPTION
This PR restricts access to the IPC used for communication between GUI and daemon on Windows.