### PR TITLE
feat: add configurable congestion controllers

### DIFF
--- a/quincy-client/src/client/mod.rs
+++ b/quincy-client/src/client/mod.rs
@@ -11,6 +11,7 @@ use quinn::{Connection, Endpoint};
 
 use ipnet::IpNet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
+use std::time::Duration;
 
 use crate::client::relayer::ClientRelayer;
 use quincy::network::interface::{Interface, InterfaceIO};
@@ -48,7 +49,10 @@ impl QuincyClient {
         let authenticator = Box::new(UsersFileClientAuthenticator::new(
             &self.config.authentication,
         ));
-        let auth_client = AuthClient::new(authenticator, self.config.connection.connection_timeout);
+        let auth_client = AuthClient::new(
+            authenticator,
+            Duration::from_secs(self.config.connection.connection_timeout_s),
+        );
 
         let (client_address, server_address) = auth_client.authenticate(&connection).await?;
 

--- a/quincy-server/src/server/mod.rs
+++ b/quincy-server/src/server/mod.rs
@@ -3,6 +3,7 @@ mod connection;
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::auth::AuthServer;
 use crate::server::connection::QuincyConnection;
@@ -67,7 +68,7 @@ impl QuincyServer {
         let auth_server = AuthServer::new(
             authenticator,
             self.config.tunnel_network,
-            self.config.connection.connection_timeout,
+            Duration::from_secs(self.config.connection.connection_timeout_s),
         );
 
         let (sender, receiver) = channel(PACKET_CHANNEL_SIZE);


### PR DESCRIPTION
This PR adds support for configuring congestion controllers available in `quinn` - Cubic, BBR or NewReno.

Closes #145 