### PR TITLE
fix: explicitly handle lenient certificate parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,6 +3509,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/quincy/Cargo.toml
+++ b/quincy/Cargo.toml
@@ -62,3 +62,6 @@ jemallocator = { workspace = true, optional = true }
 # WinTun
 [target.'cfg(windows)'.dependencies]
 wintun-bindings = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
This PR adds additional logic wrapping the lenient certificate parsing in `rustls_pemfile` to handle cases where users specify invalid certificates.

Closes #158.