### PR TITLE
fix: add progressive fallback when setting buffer sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,6 +4009,7 @@ dependencies = [
  "futures",
  "ipnet",
  "jemallocator",
+ "libc",
  "nu-ansi-term",
  "quinn",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ quinn = { version = "^0.11.8", default-features = false, features = [
 # Interfaces and networking
 tun-rs = { version = "=2.8.2", features = ["async_tokio"] } # pinned audited version
 socket2 = { version = "^0.6.0", features = ["all"] }
+libc = "^0.2"
 bytes = "^1.11"
 ipnet = { version = "^2.7", features = ["serde"] }
 

--- a/quincy/Cargo.toml
+++ b/quincy/Cargo.toml
@@ -28,6 +28,7 @@ quinn = { workspace = true }
 # Interfaces and networking
 tun-rs = { workspace = true }
 socket2 = { workspace = true }
+libc = { workspace = true }
 bytes = { workspace = true }
 ipnet = { workspace = true }
 

--- a/quincy/src/constants.rs
+++ b/quincy/src/constants.rs
@@ -13,6 +13,16 @@ pub const PACKET_BUFFER_SIZE: usize = 4;
 /// Packet channel size used for communication between the TUN interface and QUIC tunnels.
 pub const PACKET_CHANNEL_SIZE: usize = 1024 * 1024;
 
+/// Minimum socket buffer size (send/recv) that `bind_socket` will attempt
+/// before giving up and falling back to the OS default.
+///
+/// Some operating systems (FreeBSD) reject `setsockopt(SO_SNDBUF)`
+/// with `ENOBUFS` when the requested size exceeds system limits, rather than
+/// silently clamping like Linux does. The retry loop in `bind_socket` halves
+/// the requested size on each failure but stops once it would drop below this
+/// floor.
+pub const MIN_SOCKET_BUFFER_SIZE: usize = 128 * 1024;
+
 /// Represents the supported TLS protocol versions for Quincy.
 pub static TLS_PROTOCOL_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
 

--- a/quincy/src/network/socket.rs
+++ b/quincy/src/network/socket.rs
@@ -1,16 +1,23 @@
 use std::net::SocketAddr;
 
-use ::tracing::warn;
 use socket2::{Domain, Protocol, Socket, Type};
+use tracing::warn;
 
+use crate::constants::MIN_SOCKET_BUFFER_SIZE;
 use crate::error::{Result, SocketError};
 
 /// Binds a UDP socket to the given address and sets the send and receive buffer sizes.
 ///
+/// Buffer sizes are set on a best-effort basis - if the OS rejects the requested
+/// size with `ENOBUFS` (e.g. FreeBSD when the value exceeds system limits),
+/// the function halves the request repeatedly until it is accepted or
+/// [`MIN_SOCKET_BUFFER_SIZE`] is reached. Other errors are propagated
+/// immediately.
+///
 /// ### Arguments
 /// - `addr` - the address to bind the socket to
-/// - `send_buffer_size` - the size of the send buffer
-/// - `recv_buffer_size` - the size of the receive buffer
+/// - `send_buffer_size` - the desired size of the send buffer
+/// - `recv_buffer_size` - the desired size of the receive buffer
 /// - `reuse_socket` - whether to reuse the socket across multiple Quincy instances
 ///
 /// ### Returns
@@ -59,39 +66,73 @@ pub fn bind_socket(
         .map_err(|_| SocketError::BindFailed {
             address: addr.to_string(),
         })?;
-    socket
-        .set_send_buffer_size(send_buffer_size)
-        .map_err(|_| SocketError::ConfigFailed {
-            option: format!("send buffer size: {send_buffer_size}"),
-        })?;
-    socket
-        .set_recv_buffer_size(recv_buffer_size)
-        .map_err(|_| SocketError::ConfigFailed {
-            option: format!("recv buffer size: {recv_buffer_size}"),
-        })?;
 
-    let buf_size = socket
-        .send_buffer_size()
-        .map_err(|_| SocketError::ConfigFailed {
-            option: "send buffer size query".to_string(),
-        })?;
-    if buf_size < send_buffer_size {
-        warn!(
-            "Unable to set desired send buffer size. Desired: {}, Actual: {}",
-            send_buffer_size, buf_size
-        );
-    }
-
-    let buf_size = socket
-        .recv_buffer_size()
-        .map_err(|_| SocketError::ConfigFailed {
-            option: "recv buffer size query".to_string(),
-        })?;
-    if buf_size < recv_buffer_size {
-        warn!(
-            "Unable to set desired recv buffer size. Desired: {recv_buffer_size}, Actual: {buf_size}",
-        );
-    }
+    try_set_buffer_size(
+        &socket,
+        send_buffer_size,
+        Socket::set_send_buffer_size,
+        Socket::send_buffer_size,
+        "send buffer size",
+    )?;
+    try_set_buffer_size(
+        &socket,
+        recv_buffer_size,
+        Socket::set_recv_buffer_size,
+        Socket::recv_buffer_size,
+        "recv buffer size",
+    )?;
 
     Ok(socket.into())
+}
+
+/// Tries to set a socket buffer size. On `ENOBUFS`, halves the request
+/// repeatedly until it is accepted or [`MIN_SOCKET_BUFFER_SIZE`] is reached.
+/// Other errors are propagated. Emits at most one warning.
+fn try_set_buffer_size(
+    socket: &Socket,
+    requested: usize,
+    set_fn: fn(&Socket, usize) -> std::io::Result<()>,
+    get_fn: fn(&Socket) -> std::io::Result<usize>,
+    label: &str,
+) -> Result<()> {
+    if try_set_fn(socket, requested, set_fn, label)? {
+        if let Ok(actual) = get_fn(socket) {
+            if actual < requested {
+                warn!("Unable to set desired {label}. Desired: {requested}, Actual: {actual}",);
+            }
+        }
+        return Ok(());
+    }
+
+    // ENOBUFS — halve repeatedly until accepted or the floor is reached.
+    let mut size = (requested / 2).max(MIN_SOCKET_BUFFER_SIZE);
+    while size >= MIN_SOCKET_BUFFER_SIZE {
+        if try_set_fn(socket, size, set_fn, label)? {
+            warn!("Reduced {label} from {requested} to {size} due to OS buffer size limits",);
+            return Ok(());
+        }
+        size /= 2;
+    }
+
+    // Every attempt failed — fall back to the OS default.
+    warn!("Failed to set {label} (requested {requested}); using OS default");
+    Ok(())
+}
+
+/// Calls `set_fn` and returns `Ok(true)` on success, `Ok(false)` on `ENOBUFS`,
+/// or propagates any other error as `SocketError::ConfigFailed`.
+fn try_set_fn(
+    socket: &Socket,
+    size: usize,
+    set_fn: fn(&Socket, usize) -> std::io::Result<()>,
+    label: &str,
+) -> Result<bool> {
+    match set_fn(socket, size) {
+        Ok(()) => Ok(true),
+        Err(e) if e.raw_os_error().is_some_and(|e| e == libc::ENOBUFS) => Ok(false),
+        Err(_) => Err(SocketError::ConfigFailed {
+            option: format!("{label}: {size}"),
+        }
+        .into()),
+    }
 }


### PR DESCRIPTION
This PR implements a progressive fallback mechanism when setting buffer sizes to alleviate crashes on FreeBSD caused by insufficient system buffer limits.

Closes #187.